### PR TITLE
Fix for missing space in inc\head-tete-1.php

### DIFF
--- a/demos-php/inc/head-tete-1.php
+++ b/demos-php/inc/head-tete-1.php
@@ -2,7 +2,7 @@
 
 <?php if (($_PAGE['modified'] == '') || ($_PAGE['modified'] == 'YYYY-MM-DD') || ($_PAGE['modified'] == 'AAAA-MM-JJ') || ($_PAGE['modified'] == '9999-12-31')) { $_PAGE['modified'] = $_PAGE['issued']; } ?>
 <meta name="dcterms.title" content="<?php echo $_PAGE['title_' . $_PAGE['lang1']]; ?>" />
-<?php if ($_PAGE['lang2'] != '') { ?><meta name="dcterms.title" lang="<?php echo $_UNKNOWN['gcwu_meta_' . $_PAGE['lang2']]; ?>"content="<?php echo $_PAGE['title_' . $_PAGE['lang2']]; ?>" /><?php } ?>
+<?php if ($_PAGE['lang2'] != '') { ?><meta name="dcterms.title" lang="<?php echo $_UNKNOWN['gcwu_meta_' . $_PAGE['lang2']]; ?>" content="<?php echo $_PAGE['title_' . $_PAGE['lang2']]; ?>" /><?php } ?>
 
 
 <meta name="dcterms.issued" title="W3CDTF" content="<?php echo $_PAGE['issued']; ?>" />


### PR DESCRIPTION
Missing space between ?>"content causes the W3C HTML5 validator to throw an error.

Line 20, Column 37: No space between attributes.

I added a space on line 5 between the lang2 title and content attributes
