### PR TITLE
Warning title Tag should have the same as the Alt

### DIFF
--- a/dist-php/inc/head-nav.php
+++ b/dist-php/inc/head-nav.php
@@ -107,7 +107,7 @@ echo $_TITLE_;
 	// Archived Section
 	if( $_PAGE['isarchived'] == "1" ){
 		echo "<p><img src='".$_SITE['wb_archive_warn_icon']."' alt='".$_SITE['wb_archive_warn_alt_'.$_PAGE['lang1']];
-		echo "' title='".$_SITE['wb_archive_warn_title_'.$_PAGE['lang1']]."' class='margin-bottom-none' />".$_SITE['wb_archive_warn_webuse_'.$_PAGE['lang1']];
+		echo "' title='".$_SITE['wb_archive_warn_alt_'.$_PAGE['lang1']]."' class='margin-bottom-none' />".$_SITE['wb_archive_warn_webuse_'.$_PAGE['lang1']];
 		echo "</p><div id='archived' class='wet-boew-archived span-6' data-load='archived'>";
 		echo "<section><h2>".$_SITE['wb_archive_warn_head_'.$_PAGE['lang1']]."</h2>";
 		echo "<p>".$_SITE['wb_archive_warn_msg_'.$_PAGE['lang1']]."</p></section></div><div class='clear'></div>";


### PR DESCRIPTION
As for this page http://wet-boew.github.io/wet-boew/demos/archived/archived-en.html

They are using the same word for the alt tag and the title tag.

``` php
<img src="../../dist/js/images/archived/warning.gif" alt="Warning" title="Warning" class="margin-bottom-none">
```

So we can drop this line in the config file

``` php
$_SITE['wb_archive_warn_title_'.$_LANG_] = $_SITE['wb_archive_warn_alt'.$_LANG_];
```
