### PR TITLE
Reduce the repetitive UL and LI for left menu

### DIFF
--- a/dist-php/inc/foot-nav.php
+++ b/dist-php/inc/foot-nav.php
@@ -25,11 +25,15 @@ if( isset($_PAGE['issplash']) && $_PAGE['issplash'] == 1 ) {
 
         echo '<nav role="navigation" id="wb-sec" typeof="SiteNavigationElement" class="col-md-3 col-md-pull-9 visible-md visible-lg">';
 		echo '<h2>'.$_SITE['wb_sec_'.$_PAGE['lang1']] .'</h2>' . "\n";
+		echo '<ul class="list-group menu list-unstyled">';
+                echo '<li>';
         echo '<!-- SecNavStart -->' . "\n";
 
         include_once $_PAGE['left_menu_gauche'];
         
         echo '<!-- SecNavEnd -->' . "\n";
+         	echo '</li>';
+                echo '</ul>';
         echo '</nav>' . PHP_EOL;
 		echo '</div>';
 		echo '</div>';


### PR DESCRIPTION
This will reduce the repetition that we currently have for left menu.

from

``` php
<ul class="list-group menu list-unstyled">
    <li>
        <h3><a href="/contact-en.php">Contact Us</a></h3>
        <ul class="list-group menu list-unstyled">
            <li><a class="list-group-item" href="/contact-en.php?id=01">By mail</a></li>
            <li><a class="list-group-item" href="/contact-en.php?id=02">Filling a Complaint</a></li>
            <li><a class="list-group-item" href="/contact-en.php?id=03">Media contacts</a></li>
        </ul>
    </li>
</ul>

```

to

``` php
<h3><a href="/contact-en.php">Contact Us</a></h3>
<ul class="list-group menu list-unstyled">
    <li><a class="list-group-item" href="/contact-en.php?id=01">By mail</a></li>
    <li><a class="list-group-item" href="/contact-en.php?id=02">Filling a Complaint</a></li>
    <li><a class="list-group-item" href="/contact-en.php?id=03">Media contacts</a></li>
</ul>
```
