### PR TITLE
Fix to svg reference in sp-pe footer

### DIFF
--- a/dist-php/theme-gcwu-fegc/sp-pe/foot.php
+++ b/dist-php/theme-gcwu-fegc/sp-pe/foot.php
@@ -1,6 +1,6 @@
 <?php
 	echo '<footer role="contentinfo" class="container">'.PHP_EOL;
-	echo '	<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="/theme-gcwu-fegc/assets/wmms-alt.svg" aria-label="Symbol of the Government of Canada">'.PHP_EOL;
+	echo '	<object id="wmms" type="image/svg+xml" tabindex="-1" role="img" data="'.$_SITE['wb_core_root']./assets/wmms-alt.svg" aria-label="Symbol of the Government of Canada">'.PHP_EOL;
 	echo '	</object>'.PHP_EOL;
 	echo '</footer>'.PHP_EOL;
 ?>


### PR DESCRIPTION
Fix to the svg file reference in sp-pe footer so that it is based on what $_SITE['wb_core_root'] is referenced to instead of statically referenced to "/theme-gcwu-fegc".