### PR TITLE
Fix to sp-pe incorrect theme reference

### DIFF
--- a/dist-php/inc/sp-pe/head.php
+++ b/dist-php/inc/sp-pe/head.php
@@ -1,6 +1,6 @@
 <?php 
 	/* include theme specific headers if the theme specific /sp-pe/head.php file exists */
-	$_THEME_SP_PE = $_SERVER['DOCUMENT_ROOT'].$_SITE['wb_php_dist_folder'].$_SITE['wb_core_root']."/sp-pe/head.php";
+	$_THEME_SP_PE = $_SERVER['DOCUMENT_ROOT'].$_SITE['wb_php_dist_folder'].'/'.$_SITE['wb_theme']."/sp-pe/head.php";
 	if( file_exists($_THEME_SP_PE ) ) {
 		include $_THEME_SP_PE;
 	}


### PR DESCRIPTION
Fix to incorrect theme reference for the splash page header. Was set to $_SITE['wb_core_root'] instead of the theme ref:
'/'.$_SITE['wb_theme']