### PR TITLE
add input sanitization

### DIFF
--- a/dist-php/langselect/lang.php
+++ b/dist-php/langselect/lang.php
@@ -3,6 +3,44 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
+ 
+function is_dubious($input) {
+    // remove things that:
+    // - look, feel and smell like XSS
+    $dubious = array('javascript', 'vbscript', 'expression', 'applet', 'meta',
+                     'xml', 'blink', 'link', 'style', 'script', 'embed',
+                     'object', 'iframe', 'frame', 'frameset', 'ilayer',
+                     'layer', 'bgsound', 'title', 'base', 'onabort',
+                     'onactivate', 'onafter', 'onbefore', 'onblur',
+                     'onbounce', 'onclick', 'onchange', 'ondata', 'ondrag',
+                     'ondrop', 'onload', 'onunload', 'onresize', 'onmouse',
+                     'onselect', 'onkey', 'onlayout', 'oncontrol', 'onmove',
+                     'ondbl', 'focus', 'onscroll', 'onrow', 'onpaste',
+                     'onready', 'onreset', 'prompt',
+                     '"', '\'', // remove single and double quotes
+                     "\n", "\r", "\r\n", '%0d', '%0a'); // remove any CR LF
+
+    foreach($dubious as $dub) {
+        if (stristr($input, $dub)) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+if (empty($_SERVER['HTTP_REFERER'])) {
+    // don't know how we got here, blacklist and early out
+    header('HTTP/1.1 400 Bad Request', true, 400);
+    exit();
+}
+
+// brute force check for XSS/CRLF/HTTP response splitting
+if (is_dubious($_SERVER['HTTP_REFERER']) === TRUE || is_dubious($_SERVER['QUERY_STRING']) === TRUE) {
+    // dubious request, blacklist and early out
+    header('HTTP/1.1 400 Bad Request', true, 400);
+    exit();
+}
+ 
 if ($_SERVER['HTTP_REFERER'] != "") {
     $q = $_SERVER['HTTP_REFERER'];
 } else {


### PR DESCRIPTION
cc @kngai 

## Overview

This PR inspects HTTP `Referer` header and HTTP `QUERY_STRING` environment variable for dubious behaviour and throws HTTP 400 if these values are dubious **OR** the HTTP `Referer` header is empty, in the spirit of [Postel's Law](https://en.wikipedia.org/wiki/Robustness_principle).

## Rationale

- `dist-php/langselect/lang.php` should never be requested without the context of being clicked from another page (language toggle).  In other words, this script should **always** have a `Referer`
- if the request looks dubious, it's a Bad Request (400)

## Improvements

- the `$dubious` array contains a selection of string patterns, which, if a given page includes them in a non-dubious fashion (i.e.http://example.org/metadata, which will be caught by `meta`), this PR will still throw 400, resulting in a false positive.  This brute force approach can surely be improved:
  - smarter handling: this is a brute force (but safe [for our use cases]) approach
  - application level configuration directive of strings that are dubious