### PR TITLE
Added Sign in / Sign out controls

### DIFF
--- a/dist-php/config/config-de.php
+++ b/dist-php/config/config-de.php
@@ -1,41 +1,50 @@
 <?php
-	/*	THIS FILE REQUIRES TRANSLATION */
+	/* THIS FILE REQUIRES TRANSLATION */
 	$_LANG_ = "de";
-	$_SITE['wb_meta_'.$_LANG_] = "de"; 
-	$_SITE['wb_lang_text_'.$_LANG_] = "Deutsch"; 
+	$_SITE['wb_meta_'.$_LANG_] = "de";
+	$_SITE['wb_lang_text_'.$_LANG_] = "Deutsch";
 	$_SITE['wb_lang_cur_'.$_LANG_] = "(current)";
 
-	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content"; 
-	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu"; 
-	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information"; 
-	
-	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant"; 
-	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php"; 
+	$_SITE['theme_list_'.$_LANG_] = array(
+		"theme-gcwu-fegc" => "Government of Canada Web Usability theme",
+		"theme-gcweb" => "Canada.ca theme",
+		"theme-wet-boew" => "WET theme",
+		"theme-gc-intranet" => "Government of Canada Web Usability Intranet theme",
+		"theme-ogpl" => "OGPL theme",
+		"theme-base" => "Base theme",
+	);
+
+	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content";
+	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu";
+	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information";
+
+	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant";
+	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php";
 
 	$_SITE['wb_lang_header_'.$_LANG_] = "Language selection";
 
 	$_SITE['wb_terms_'.$_LANG_] = "Terms and conditions of use";
-	$_SITE['wb_terms_href_'.$_LANG_] = "../../License-en.html";
+	$_SITE['wb_terms_href_'.$_LANG_] = "../../license-en.php";
 
-	$_SITE['wb_mb_menu_'.$_LANG_] = "Menu";
+	$_SITE['wb_mb_menu_'.$_LANG_] = "Search and menus";
 
-	//used in foot-nav.php
-	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu"; 
+	// Used in foot-nav.php.
+	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu";
 
-	//used in cont/foot.php
-	$_SITE['wb_foot_'.$_LANG_] = "Site Information"; 
+	// Used in cont/foot.php.
+	$_SITE['wb_foot_'.$_LANG_] = "About this site";
 
-	//$_MENU_LOCATION__ is set in the parent config.php file
+	// $_MENU_LOCATION__ is set in the parent config.php file.
 	$_SITE['wb_sitenav_file_'.$_LANG_] = $_MENU_LOCATION_ ."/prim-megamenu-en.php";
-	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu"; 
+	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu";
 
 	$_SITE['wb_ft1_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-1-en.php";
 	$_SITE['wb_ft1_href_'.$_LANG_] = "#";
-	$_SITE['wb_ft1_text_'.$_LANG_] = "About";
+	$_SITE['wb_ft1_text_'.$_LANG_] = "Contact us";
 
 	$_SITE['wb_ft2_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-2-en.php";
 	$_SITE['wb_ft2_href_'.$_LANG_] = "#";
-	$_SITE['wb_ft2_text_'.$_LANG_] = "Contact us";
+	$_SITE['wb_ft2_text_'.$_LANG_] = "About";
 
 	$_SITE['wb_ft3_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-3-en.php";
 	$_SITE['wb_ft3_href_'.$_LANG_] = "#";
@@ -44,45 +53,51 @@
 	$_SITE['wb_ft4_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-4-en.php";
 	$_SITE['wb_ft4_href_'.$_LANG_] = "#";
 	$_SITE['wb_ft4_text_'.$_LANG_] = "Stay connected";
-	
-	$_SITE['wb_search_'.$_LANG_] = "Search"; 
-	$_SITE['wb_search_label_'.$_LANG_] = "Search Website"; 
 
-	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail"; 
-	
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:";
+	$_SITE['wb_search_'.$_LANG_] = "Search";
+	$_SITE['wb_search_label_'.$_LANG_] = "Search Website";
 
+	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail";
+
+	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; // Visible if $_SITE['isapp'] == 0.
+	$_SITE['wb_doc_version_'.$_LANG_] = "Version:";     // Visible if $_SITE['isapp'] == 1.
+
+	// Visible if $_PAGE['isarchived'] == 1.
 	$_SITE['wb_archive_title_'.$_LANG_] = "ARCHIVED - ";
 	$_SITE['wb_archive_panel_title_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "warrning";
+	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "Warning";
 	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	
-	//The following variables were used in version 3.1, but not in version 4.0
-	/*	
-	//Modify to point to a custom signin/signout application
-	//Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos
-	$_SITE['wb_signin_file_'.$_LANG_] = "application-signout-en.php";
+
+	$_STIE['wb_err_return_text_'.$_LANG_] = "Return to the ";
+	$_STIE['wb_err_return_link_'.$_LANG_] = "home page";
+
+	// Modify to point to a custom button bar.
+	$_SITE['wb_buttonbar_file_'.$_LANG_] = "../inc/button-bar.php";
+
+	// Modify to point to a custom signin application.
+	// Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signin'] == 1.
+	$_SITE['wb_signin_href_'.$_LANG_] = "#";
+	$_SITE['wb_signininfo_text_'.$_LANG_] = "Sign-on information";
 	$_SITE['wb_signin_text_'.$_LANG_] = "Sign in";
-	
-	//Modify to point to a custom signin/signout application
-	//Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos
-	$_SITE['wb_signout_file_'.$_LANG_] = "application-signin-en.php";
+
+	// Modify to point to a custom registration application.
+	// Override the 'wb_register_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['register'] == 1 and $_PAGE['signin'] == 1.
+	$_SITE['wb_register_href_'.$_LANG_] = "#";
+	$_SITE['wb_register_text_'.$_LANG_] = "Register";
+
+	// Modify to point to a custom signout application.
+	// Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signout'] == 1.
+	$_SITE['wb_signout_href_'.$_LANG_] = "#";
 	$_SITE['wb_signout_text_'.$_LANG_] = "Sign out";
+	$_SITE['wb_signedinas_text_'.$_LANG_] = "Signed in as";
+	$_SITE['wb_username_text'] = "";
 
-	//Modify to point to a custom account settings application when using sign in/sign out button
-	$_SITE['wb_sio_file_'.$_LANG_] = "#";
-	$_SITE['wb_sio_text_'.$_LANG_] = "Account settings";
-	$_SITE['wb_sio_heading_'.$_LANG_] = "My account";
-
-	$_SITE['wb_sup_'.$_LANG_] = "Supplemental content"; 
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; 
-	$_SITE['wb_doc_version_'.$_LANG_] = "Version:"; 
-	$_SITE['wb_sitefooter_'.$_LANG_] = "Site footer"; 
-
-	$_SITE['wb_archive_warn_alt_'.$_LANG_] = "Warning";
-	$_SITE['wb_archive_warn_title_'.$_LANG_] = $_SITE['wb_archive_warn_alt'.$_LANG_];
-	$_SITE['wb_archive_warn_webuse_'.$_LANG_] = "The <a href='http://www.tbs-sct.gc.ca/pol/doc-en.aspx?id=24227'>Standard on Web Usability</a> replaces this content. This content is archived because Common Look and Feel 2.0 Standards have been rescinded.";
-	$_SITE['wb_archive_warn_head_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	*/
-?>
+	// Modify to point to a custom account settings application.
+	// Override the 'wb_settings_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['settings'] == 1 and $_PAGE['signout'] == 1.
+	$_SITE['wb_settings_href_'.$_LANG_] = "#";
+	$_SITE['wb_settings_text_'.$_LANG_] = "Account settings";
+	$_SITE['wb_settings_heading_'.$_LANG_] = "My account";

--- a/dist-php/config/config-en.php
+++ b/dist-php/config/config-en.php
@@ -1,41 +1,41 @@
 <?php
 	$_LANG_ = "en";
 	$_SITE['wb_meta_'.$_LANG_] = "en";
-	$_SITE['wb_lang_text_'.$_LANG_] = "English"; 
+	$_SITE['wb_lang_text_'.$_LANG_] = "English";
 	$_SITE['wb_lang_cur_'.$_LANG_] = "(current)";
 
-    $_SITE['theme_list_'.$_LANG_] = array(
-            "theme-gcwu-fegc" => "Government of Canada Web Usability theme",
-            "theme-gcweb" => "Canada.ca theme",
-            "theme-wet-boew" => "WET theme",
-            "theme-gc-intranet" => "Government of Canada Web Usability Intranet theme",
-            "theme-ogpl" => "OGPL theme",
-            "theme-base" => "Base theme",
-    );
-	
-	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content"; 
-	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu"; 
-	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information"; 
-	
-	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant"; 
-	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php"; 
+	$_SITE['theme_list_'.$_LANG_] = array(
+		"theme-gcwu-fegc" => "Government of Canada Web Usability theme",
+		"theme-gcweb" => "Canada.ca theme",
+		"theme-wet-boew" => "WET theme",
+		"theme-gc-intranet" => "Government of Canada Web Usability Intranet theme",
+		"theme-ogpl" => "OGPL theme",
+		"theme-base" => "Base theme",
+	);
+
+	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content";
+	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu";
+	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information";
+
+	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant";
+	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php";
 
 	$_SITE['wb_lang_header_'.$_LANG_] = "Language selection";
 
 	$_SITE['wb_terms_'.$_LANG_] = "Terms and conditions of use";
 	$_SITE['wb_terms_href_'.$_LANG_] = "../../license-en.php";
-	
+
 	$_SITE['wb_mb_menu_'.$_LANG_] = "Search and menus";
 
-	//used in foot-nav.php
-	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu"; 
+	// Used in foot-nav.php.
+	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu";
 
-	//used in cont/foot.php
-	$_SITE['wb_foot_'.$_LANG_] = "About this site"; 
+	// Used in cont/foot.php.
+	$_SITE['wb_foot_'.$_LANG_] = "About this site";
 
-	//$_MENU_LOCATION__ is set in the parent config.php file
+	// $_MENU_LOCATION__ is set in the parent config.php file.
 	$_SITE['wb_sitenav_file_'.$_LANG_] = $_MENU_LOCATION_ ."/prim-megamenu-en.php";
-	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu"; 
+	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu";
 
 	$_SITE['wb_ft1_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-1-en.php";
 	$_SITE['wb_ft1_href_'.$_LANG_] = "#";
@@ -52,42 +52,51 @@
 	$_SITE['wb_ft4_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-4-en.php";
 	$_SITE['wb_ft4_href_'.$_LANG_] = "#";
 	$_SITE['wb_ft4_text_'.$_LANG_] = "Stay connected";
-	
-	$_SITE['wb_search_'.$_LANG_] = "Search"; 
-	$_SITE['wb_search_label_'.$_LANG_] = "Search Website"; 
 
-	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail"; 
-	
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:";
+	$_SITE['wb_search_'.$_LANG_] = "Search";
+	$_SITE['wb_search_label_'.$_LANG_] = "Search Website";
 
+	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail";
+
+	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; // Visible if $_SITE['isapp'] == 0.
+	$_SITE['wb_doc_version_'.$_LANG_] = "Version:";     // Visible if $_SITE['isapp'] == 1.
+
+	// Visible if $_PAGE['isarchived'] == 1.
 	$_SITE['wb_archive_title_'.$_LANG_] = "ARCHIVED - ";
 	$_SITE['wb_archive_panel_title_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "warrning";
+	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "Warning";
 	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	
-	$_STIE['wb_err_return_text_'.$_LANG_] = 'Return to the ';
-	$_STIE['wb_err_return_link_'.$_LANG_] = 'home page';
 
-        //The following variables were used in version 3.1, but not in version 4.0
-        /*
-        //Modify to point to a custom signin/signout application
-        //Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos
-        $_SITE['wb_signin_file_'.$_LANG_] = "application-signout-en.php";
-        $_SITE['wb_signin_text_'.$_LANG_] = "Sign in";
+	$_STIE['wb_err_return_text_'.$_LANG_] = "Return to the ";
+	$_STIE['wb_err_return_link_'.$_LANG_] = "home page";
 
-        //Modify to point to a custom signin/signout application
-        //Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos
-        $_SITE['wb_signout_file_'.$_LANG_] = "application-signin-en.php";
-        $_SITE['wb_signout_text_'.$_LANG_] = "Sign out";
+	// Modify to point to a custom button bar.
+	$_SITE['wb_buttonbar_file_'.$_LANG_] = "../inc/button-bar.php";
 
-        //Modify to point to a custom account settings application when using sign in/sign out button
-        $_SITE['wb_sio_file_'.$_LANG_] = "#";
-        $_SITE['wb_sio_text_'.$_LANG_] = "Account settings";
-        $_SITE['wb_sio_heading_'.$_LANG_] = "My account";
+	// Modify to point to a custom signin application.
+	// Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signin'] == 1.
+	$_SITE['wb_signin_href_'.$_LANG_] = "#";
+	$_SITE['wb_signininfo_text_'.$_LANG_] = "Sign-on information";
+	$_SITE['wb_signin_text_'.$_LANG_] = "Sign in";
 
-        $_SITE['wb_sup_'.$_LANG_] = "Supplemental content";
-        $_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:";
-        $_SITE['wb_doc_version_'.$_LANG_] = "Version:";
-        $_SITE['wb_sitefooter_'.$_LANG_] = "Site footer";
-        */
-?>
+	// Modify to point to a custom registration application.
+	// Override the 'wb_register_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['register'] == 1 and $_PAGE['signin'] == 1.
+	$_SITE['wb_register_href_'.$_LANG_] = "#";
+	$_SITE['wb_register_text_'.$_LANG_] = "Register";
+
+	// Modify to point to a custom signout application.
+	// Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signout'] == 1.
+	$_SITE['wb_signout_href_'.$_LANG_] = "#";
+	$_SITE['wb_signout_text_'.$_LANG_] = "Sign out";
+	$_SITE['wb_signedinas_text_'.$_LANG_] = "Signed in as";
+	$_SITE['wb_username_text'] = "";
+
+	// Modify to point to a custom account settings application.
+	// Override the 'wb_settings_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['settings'] == 1 and $_PAGE['signout'] == 1.
+	$_SITE['wb_settings_href_'.$_LANG_] = "#";
+	$_SITE['wb_settings_text_'.$_LANG_] = "Account settings";
+	$_SITE['wb_settings_heading_'.$_LANG_] = "My account";

--- a/dist-php/config/config-es.php
+++ b/dist-php/config/config-es.php
@@ -1,41 +1,50 @@
 <?php
-	/*	THIS FILE REQUIRES TRANSLATION */
+	/* THIS FILE REQUIRES TRANSLATION */
 	$_LANG_ = "es";
-	$_SITE['wb_meta_'.$_LANG_] = "es"; 
-	$_SITE['wb_lang_text_'.$_LANG_] = "Español"; 
+	$_SITE['wb_meta_'.$_LANG_] = "es";
+	$_SITE['wb_lang_text_'.$_LANG_] = "Español";
 	$_SITE['wb_lang_cur_'.$_LANG_] = "(current)";
 
-	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content"; 
-	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu"; 
-	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information"; 
-	
-	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant"; 
-	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php"; 
+	$_SITE['theme_list_'.$_LANG_] = array(
+		"theme-gcwu-fegc" => "Government of Canada Web Usability theme",
+		"theme-gcweb" => "Canada.ca theme",
+		"theme-wet-boew" => "WET theme",
+		"theme-gc-intranet" => "Government of Canada Web Usability Intranet theme",
+		"theme-ogpl" => "OGPL theme",
+		"theme-base" => "Base theme",
+	);
+
+	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content";
+	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu";
+	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information";
+
+	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant";
+	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php";
 
 	$_SITE['wb_lang_header_'.$_LANG_] = "Language selection";
 
 	$_SITE['wb_terms_'.$_LANG_] = "Terms and conditions of use";
-	$_SITE['wb_terms_href_'.$_LANG_] = "../../License-en.html";
+	$_SITE['wb_terms_href_'.$_LANG_] = "../../license-en.php";
 
-	$_SITE['wb_mb_menu_'.$_LANG_] = "Menu";
+	$_SITE['wb_mb_menu_'.$_LANG_] = "Search and menus";
 
-	//used in foot-nav.php
-	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu"; 
+	// Used in foot-nav.php.
+	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu";
 
-	//used in cont/foot.php
-	$_SITE['wb_foot_'.$_LANG_] = "Site Information"; 
+	// Used in cont/foot.php.
+	$_SITE['wb_foot_'.$_LANG_] = "About this site";
 
-	//$_MENU_LOCATION__ is set in the parent config.php file
+	// $_MENU_LOCATION__ is set in the parent config.php file.
 	$_SITE['wb_sitenav_file_'.$_LANG_] = $_MENU_LOCATION_ ."/prim-megamenu-en.php";
-	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu"; 
+	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu";
 
 	$_SITE['wb_ft1_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-1-en.php";
 	$_SITE['wb_ft1_href_'.$_LANG_] = "#";
-	$_SITE['wb_ft1_text_'.$_LANG_] = "About";
+	$_SITE['wb_ft1_text_'.$_LANG_] = "Contact us";
 
 	$_SITE['wb_ft2_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-2-en.php";
 	$_SITE['wb_ft2_href_'.$_LANG_] = "#";
-	$_SITE['wb_ft2_text_'.$_LANG_] = "Contact us";
+	$_SITE['wb_ft2_text_'.$_LANG_] = "About";
 
 	$_SITE['wb_ft3_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-3-en.php";
 	$_SITE['wb_ft3_href_'.$_LANG_] = "#";
@@ -44,48 +53,51 @@
 	$_SITE['wb_ft4_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-4-en.php";
 	$_SITE['wb_ft4_href_'.$_LANG_] = "#";
 	$_SITE['wb_ft4_text_'.$_LANG_] = "Stay connected";
-	
-	$_SITE['wb_search_'.$_LANG_] = "Search"; 
-	$_SITE['wb_search_label_'.$_LANG_] = "Search Website"; 
 
-	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail"; 
-	
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:";
+	$_SITE['wb_search_'.$_LANG_] = "Search";
+	$_SITE['wb_search_label_'.$_LANG_] = "Search Website";
 
-	$_STIE['wb_err_return_text_'.$_LANG_] = 'Return to the ';
-	$_STIE['wb_err_return_link_'.$_LANG_] = 'home page';
-	
+	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail";
+
+	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; // Visible if $_SITE['isapp'] == 0.
+	$_SITE['wb_doc_version_'.$_LANG_] = "Version:";     // Visible if $_SITE['isapp'] == 1.
+
+	// Visible if $_PAGE['isarchived'] == 1.
 	$_SITE['wb_archive_title_'.$_LANG_] = "ARCHIVED - ";
 	$_SITE['wb_archive_panel_title_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "warrning";
+	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "Warning";
 	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	
-	//The following variables were used in version 3.1, but not in version 4.0
-	/*	
-	//Modify to point to a custom signin/signout application
-	//Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos
-	$_SITE['wb_signin_file_'.$_LANG_] = "application-signout-en.php";
+
+	$_STIE['wb_err_return_text_'.$_LANG_] = "Return to the ";
+	$_STIE['wb_err_return_link_'.$_LANG_] = "home page";
+
+	// Modify to point to a custom button bar.
+	$_SITE['wb_buttonbar_file_'.$_LANG_] = "../inc/button-bar.php";
+
+	// Modify to point to a custom signin application.
+	// Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signin'] == 1.
+	$_SITE['wb_signin_href_'.$_LANG_] = "#";
+	$_SITE['wb_signininfo_text_'.$_LANG_] = "Sign-on information";
 	$_SITE['wb_signin_text_'.$_LANG_] = "Sign in";
-	
-	//Modify to point to a custom signin/signout application
-	//Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos
-	$_SITE['wb_signout_file_'.$_LANG_] = "application-signin-en.php";
+
+	// Modify to point to a custom registration application.
+	// Override the 'wb_register_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['register'] == 1 and $_PAGE['signin'] == 1.
+	$_SITE['wb_register_href_'.$_LANG_] = "#";
+	$_SITE['wb_register_text_'.$_LANG_] = "Register";
+
+	// Modify to point to a custom signout application.
+	// Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signout'] == 1.
+	$_SITE['wb_signout_href_'.$_LANG_] = "#";
 	$_SITE['wb_signout_text_'.$_LANG_] = "Sign out";
+	$_SITE['wb_signedinas_text_'.$_LANG_] = "Signed in as";
+	$_SITE['wb_username_text'] = "";
 
-	//Modify to point to a custom account settings application when using sign in/sign out button
-	$_SITE['wb_sio_file_'.$_LANG_] = "#";
-	$_SITE['wb_sio_text_'.$_LANG_] = "Account settings";
-	$_SITE['wb_sio_heading_'.$_LANG_] = "My account";
-
-	$_SITE['wb_sup_'.$_LANG_] = "Supplemental content"; 
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; 
-	$_SITE['wb_doc_version_'.$_LANG_] = "Version:"; 
-	$_SITE['wb_sitefooter_'.$_LANG_] = "Site footer"; 
-
-	$_SITE['wb_archive_warn_alt_'.$_LANG_] = "Warning";
-	$_SITE['wb_archive_warn_title_'.$_LANG_] = $_SITE['wb_archive_warn_alt'.$_LANG_];
-	$_SITE['wb_archive_warn_webuse_'.$_LANG_] = "The <a href='http://www.tbs-sct.gc.ca/pol/doc-en.aspx?id=24227'>Standard on Web Usability</a> replaces this content. This content is archived because Common Look and Feel 2.0 Standards have been rescinded.";
-	$_SITE['wb_archive_warn_head_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	*/
-?>
+	// Modify to point to a custom account settings application.
+	// Override the 'wb_settings_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['settings'] == 1 and $_PAGE['signout'] == 1.
+	$_SITE['wb_settings_href_'.$_LANG_] = "#";
+	$_SITE['wb_settings_text_'.$_LANG_] = "Account settings";
+	$_SITE['wb_settings_heading_'.$_LANG_] = "My account";

--- a/dist-php/config/config-fr.php
+++ b/dist-php/config/config-fr.php
@@ -4,14 +4,14 @@
 	$_SITE['wb_lang_text_'.$_LANG_] = "Français";
 	$_SITE['wb_lang_cur_'.$_LANG_] = "(courant)";
 
-    $_SITE['theme_list_'.$_LANG_] = array(
-            "theme-gcwu-fegc" => "Thème de la facilité d’emploi Web du gouvernement du Canada",
-            "theme-gcweb" => "Thème Canada.ca",
-            "theme-wet-boew" => "Thème de la BOEW",
-            "theme-gc-intranet" => "Thème intranet de la facilité d’emploi Web du gouvernement du Canada",
-            "theme-ogpl" => "Thème PGO",
-            "theme-base" => "Thème de base",
-    );
+	$_SITE['theme_list_'.$_LANG_] = array(
+		"theme-gcwu-fegc" => "Thème de la facilité d’emploi Web du gouvernement du Canada",
+		"theme-gcweb" => "Thème Canada.ca",
+		"theme-wet-boew" => "Thème de la BOEW",
+		"theme-gc-intranet" => "Thème intranet de la facilité d’emploi Web du gouvernement du Canada",
+		"theme-ogpl" => "Thème PGO",
+		"theme-base" => "Thème de base",
+	);
 
 	$_SITE['wb_sh_link_1_'.$_LANG_] = "Passer au contenu principal";
 	$_SITE['wb_sh_link_2_'.$_LANG_] = "Passer au menu secondaire";
@@ -27,13 +27,13 @@
 
 	$_SITE['wb_mb_menu_'.$_LANG_] = "Recherche et menus";
 
-	//used in foot-nav.php
+	// Used in foot-nav.php.
 	$_SITE['wb_sec_'.$_LANG_] = "Menu secondaire";
 
-	//used in cont/foot.php
+	// Used in cont/foot.php.
 	$_SITE['wb_foot_'.$_LANG_] = "À propos de ce site";
 
-	//$_MENU_LOCATION__ is set in the parent config.php file
+	// $_MENU_LOCATION__ is set in the parent config.php file.
 	$_SITE['wb_sitenav_file_'.$_LANG_] = $_MENU_LOCATION_ ."/prim-megamenu-fr.php";
 	$_SITE['wb_sitenav_'.$_LANG_] = "Menu du site";
 
@@ -57,39 +57,46 @@
 	$_SITE['wb_search_label_'.$_LANG_] = "Recherchez le site Web";
 
 	$_SITE['wb_bcrumb_'.$_LANG_] = "Fil d'Ariane";
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date de modification&nbsp;:";
 
+	$_SITE['wb_doc_dates_'.$_LANG_] = "Date de modification&nbsp;:"; // Visible if $_SITE['isapp'] == 0.
+	$_SITE['wb_doc_version_'.$_LANG_] = "Version&nbsp;:";            // Visible if $_SITE['isapp'] == 1.
+
+	// Visible if $_PAGE['isarchived'] == 1.
 	$_SITE['wb_archive_title_'.$_LANG_] = "ARCHIV&Eacute;E - ";
 	$_SITE['wb_archive_panel_title_'.$_LANG_] = "Contenu archivé";
 	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "Avertissement";
 	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "L'information dont il est indiqué qu'elle est archivée est fournie à des fins de référence, de recherche ou de tenue de documents. Elle n'est pas assujettie aux normes Web du gouvernement du Canada et elle n'a pas été modifiée ou mise à jour depuis son archivage. Pour obtenir cette information dans un autre format, veuillez communiquer avec nous.";
 
-	$_STIE['wb_err_return_text_'.$_LANG_] = 'Retournez à la ';
-	$_STIE['wb_err_return_link_'.$_LANG_] = 'page d\'accueil';
+	$_STIE['wb_err_return_text_'.$_LANG_] = "Retournez à la ";
+	$_STIE['wb_err_return_link_'.$_LANG_] = "page d'accueil";
 
-        //The following variables were used in version 3.1, but not in version 4.0
-        /*
-        //Modify to point to a custom signin/signout application
-        //Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos
-        $_SITE['wb_signin_file_'.$_LANG_] = "application-signout-fr.php";
-        $_SITE['wb_signin_text_'.$_LANG_] = "Ouvrir une session";
+	// Modify to point to a custom button bar.
+	$_SITE['wb_buttonbar_file_'.$_LANG_] = "../inc/button-bar.php";
 
-        //Modify to point to a custom signin/signout application
-        //Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos
-        $_SITE['wb_signout_file_'.$_LANG_] = "application-signin-fr.php";
-        $_SITE['wb_signout_text_'.$_LANG_] = "Fermer la session";
+	// Modify to point to a custom signin application.
+	// Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signin'] == 1.
+	$_SITE['wb_signin_href_'.$_LANG_] = "#";
+	$_SITE['wb_signininfo_text_'.$_LANG_] = "Information de l'utilisateur actuel";
+	$_SITE['wb_signin_text_'.$_LANG_] = "Ouvrir une session";
 
-        //Modify to point to a custom account settings application when using sign in/sign out button
-        $_SITE['wb_sio_file_'.$_LANG_] = "#";
-        $_SITE['wb_sio_text_'.$_LANG_] = "Paramètres du compte";
+	// Modify to point to a custom registration application.
+	// Override the 'wb_register_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['register'] == 1 and $_PAGE['signin'] == 1.
+	$_SITE['wb_register_href_'.$_LANG_] = "#";
+	$_SITE['wb_register_text_'.$_LANG_] = "Inscription";
 
-        $_SITE['wb_sio_heading_'.$_LANG_] = "Mon compte";
+	// Modify to point to a custom signout application.
+	// Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signout'] == 1.
+	$_SITE['wb_signout_href_'.$_LANG_] = "#";
+	$_SITE['wb_signout_text_'.$_LANG_] = "Fermer la session";
+	$_SITE['wb_signedinas_text_'.$_LANG_] = "Connecté en tant que";
+	$_SITE['wb_username_text'] = "";
 
-        $_SITE['wb_sup_'.$_LANG_] = "Contenu supplémentaire";
-        $_SITE['wb_doc_dates_'.$_LANG_] = "Date de modification&nbsp;:";
-        $_SITE['wb_doc_version_'.$_LANG_] = "Version&nbsp;:";
-        $_SITE['wb_sitefooter_'.$_LANG_] = "Pied de page du site";
-
-
-        */
-?>
+	// Modify to point to a custom account settings application.
+	// Override the 'wb_settings_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['settings'] == 1 and $_PAGE['signout'] == 1.
+	$_SITE['wb_settings_url_'.$_LANG_] = "#";
+	$_SITE['wb_settings_text_'.$_LANG_] = "Paramètres du compte";
+	$_SITE['wb_settings_heading_'.$_LANG_] = "Mon compte";

--- a/dist-php/config/config-it.php
+++ b/dist-php/config/config-it.php
@@ -1,41 +1,50 @@
 <?php
-	/*	THIS FILE REQUIRES TRANSLATION */
+	/* THIS FILE REQUIRES TRANSLATION */
 	$_LANG_ = "it";
-	$_SITE['wb_meta_'.$_LANG_] = "it"; 
-	$_SITE['wb_lang_text_'.$_LANG_] = "Italiano"; 
+	$_SITE['wb_meta_'.$_LANG_] = "it";
+	$_SITE['wb_lang_text_'.$_LANG_] = "Italiano";
 	$_SITE['wb_lang_cur_'.$_LANG_] = "(current)";
 
-	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content"; 
-	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu"; 
-	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information"; 
-	
-	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant"; 
-	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php"; 
+	$_SITE['theme_list_'.$_LANG_] = array(
+		"theme-gcwu-fegc" => "Government of Canada Web Usability theme",
+		"theme-gcweb" => "Canada.ca theme",
+		"theme-wet-boew" => "WET theme",
+		"theme-gc-intranet" => "Government of Canada Web Usability Intranet theme",
+		"theme-ogpl" => "OGPL theme",
+		"theme-base" => "Base theme",
+	);
+
+	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content";
+	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu";
+	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information";
+
+	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant";
+	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php";
 
 	$_SITE['wb_lang_header_'.$_LANG_] = "Language selection";
 
 	$_SITE['wb_terms_'.$_LANG_] = "Terms and conditions of use";
-	$_SITE['wb_terms_href_'.$_LANG_] = "../../License-en.html";
+	$_SITE['wb_terms_href_'.$_LANG_] = "../../license-en.php";
 
-	$_SITE['wb_mb_menu_'.$_LANG_] = "Menu";
+	$_SITE['wb_mb_menu_'.$_LANG_] = "Search and menus";
 
-	//used in foot-nav.php
-	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu"; 
+	// Used in foot-nav.php.
+	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu";
 
-	//used in cont/foot.php
-	$_SITE['wb_foot_'.$_LANG_] = "Site Information"; 
+	// Used in cont/foot.php.
+	$_SITE['wb_foot_'.$_LANG_] = "About this site";
 
-	//$_MENU_LOCATION__ is set in the parent config.php file
+	// $_MENU_LOCATION__ is set in the parent config.php file.
 	$_SITE['wb_sitenav_file_'.$_LANG_] = $_MENU_LOCATION_ ."/prim-megamenu-en.php";
-	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu"; 
+	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu";
 
 	$_SITE['wb_ft1_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-1-en.php";
 	$_SITE['wb_ft1_href_'.$_LANG_] = "#";
-	$_SITE['wb_ft1_text_'.$_LANG_] = "About";
+	$_SITE['wb_ft1_text_'.$_LANG_] = "Contact us";
 
 	$_SITE['wb_ft2_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-2-en.php";
 	$_SITE['wb_ft2_href_'.$_LANG_] = "#";
-	$_SITE['wb_ft2_text_'.$_LANG_] = "Contact us";
+	$_SITE['wb_ft2_text_'.$_LANG_] = "About";
 
 	$_SITE['wb_ft3_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-3-en.php";
 	$_SITE['wb_ft3_href_'.$_LANG_] = "#";
@@ -44,48 +53,51 @@
 	$_SITE['wb_ft4_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-4-en.php";
 	$_SITE['wb_ft4_href_'.$_LANG_] = "#";
 	$_SITE['wb_ft4_text_'.$_LANG_] = "Stay connected";
-	
-	$_SITE['wb_search_'.$_LANG_] = "Search"; 
-	$_SITE['wb_search_label_'.$_LANG_] = "Search Website"; 
 
-	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail"; 
-	
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:";
+	$_SITE['wb_search_'.$_LANG_] = "Search";
+	$_SITE['wb_search_label_'.$_LANG_] = "Search Website";
 
-	$_STIE['wb_err_return_text_'.$_LANG_] = 'Return to the ';
-	$_STIE['wb_err_return_link_'.$_LANG_] = 'home page';
+	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail";
 
+	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; // Visible if $_SITE['isapp'] == 0.
+	$_SITE['wb_doc_version_'.$_LANG_] = "Version:";     // Visible if $_SITE['isapp'] == 1.
+
+	// Visible if $_PAGE['isarchived'] == 1.
 	$_SITE['wb_archive_title_'.$_LANG_] = "ARCHIVED - ";
 	$_SITE['wb_archive_panel_title_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "warrning";
+	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "Warning";
 	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	
-	//The following variables were used in version 3.1, but not in version 4.0
-	/*	
-	//Modify to point to a custom signin/signout application
-	//Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos
-	$_SITE['wb_signin_file_'.$_LANG_] = "application-signout-en.php";
+
+	$_STIE['wb_err_return_text_'.$_LANG_] = "Return to the ";
+	$_STIE['wb_err_return_link_'.$_LANG_] = "home page";
+
+	// Modify to point to a custom button bar.
+	$_SITE['wb_buttonbar_file_'.$_LANG_] = "../inc/button-bar.php";
+
+	// Modify to point to a custom signin application.
+	// Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signin'] == 1.
+	$_SITE['wb_signin_href_'.$_LANG_] = "#";
+	$_SITE['wb_signininfo_text_'.$_LANG_] = "Sign-on information";
 	$_SITE['wb_signin_text_'.$_LANG_] = "Sign in";
-	
-	//Modify to point to a custom signin/signout application
-	//Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos
-	$_SITE['wb_signout_file_'.$_LANG_] = "application-signin-en.php";
+
+	// Modify to point to a custom registration application.
+	// Override the 'wb_register_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['register'] == 1 and $_PAGE['signin'] == 1.
+	$_SITE['wb_register_href_'.$_LANG_] = "#";
+	$_SITE['wb_register_text_'.$_LANG_] = "Register";
+
+	// Modify to point to a custom signout application.
+	// Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signout'] == 1.
+	$_SITE['wb_signout_href_'.$_LANG_] = "#";
 	$_SITE['wb_signout_text_'.$_LANG_] = "Sign out";
+	$_SITE['wb_signedinas_text_'.$_LANG_] = "Signed in as";
+	$_SITE['wb_username_text'] = "";
 
-	//Modify to point to a custom account settings application when using sign in/sign out button
-	$_SITE['wb_sio_file_'.$_LANG_] = "#";
-	$_SITE['wb_sio_text_'.$_LANG_] = "Account settings";
-	$_SITE['wb_sio_heading_'.$_LANG_] = "My account";
-
-	$_SITE['wb_sup_'.$_LANG_] = "Supplemental content"; 
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; 
-	$_SITE['wb_doc_version_'.$_LANG_] = "Version:"; 
-	$_SITE['wb_sitefooter_'.$_LANG_] = "Site footer"; 
-
-	$_SITE['wb_archive_warn_alt_'.$_LANG_] = "Warning";
-	$_SITE['wb_archive_warn_title_'.$_LANG_] = $_SITE['wb_archive_warn_alt'.$_LANG_];
-	$_SITE['wb_archive_warn_webuse_'.$_LANG_] = "The <a href='http://www.tbs-sct.gc.ca/pol/doc-en.aspx?id=24227'>Standard on Web Usability</a> replaces this content. This content is archived because Common Look and Feel 2.0 Standards have been rescinded.";
-	$_SITE['wb_archive_warn_head_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	*/
-?>
+	// Modify to point to a custom account settings application.
+	// Override the 'wb_settings_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['settings'] == 1 and $_PAGE['signout'] == 1.
+	$_SITE['wb_settings_href_'.$_LANG_] = "#";
+	$_SITE['wb_settings_text_'.$_LANG_] = "Account settings";
+	$_SITE['wb_settings_heading_'.$_LANG_] = "My account";

--- a/dist-php/config/config-pt.php
+++ b/dist-php/config/config-pt.php
@@ -1,41 +1,50 @@
 <?php
-	/*	THIS FILE REQUIRES TRANSLATION */
+	/* THIS FILE REQUIRES TRANSLATION */
 	$_LANG_ = "pt";
-	$_SITE['wb_meta_'.$_LANG_] = "pt"; 
-	$_SITE['wb_lang_text_'.$_LANG_] = "Português"; 
+	$_SITE['wb_meta_'.$_LANG_] = "pt";
+	$_SITE['wb_lang_text_'.$_LANG_] = "Português";
 	$_SITE['wb_lang_cur_'.$_LANG_] = "(current)";
 
-	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content"; 
-	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu"; 
-	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information"; 
-	
-	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant"; 
-	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php"; 
+	$_SITE['theme_list_'.$_LANG_] = array(
+		"theme-gcwu-fegc" => "Government of Canada Web Usability theme",
+		"theme-gcweb" => "Canada.ca theme",
+		"theme-wet-boew" => "WET theme",
+		"theme-gc-intranet" => "Government of Canada Web Usability Intranet theme",
+		"theme-ogpl" => "OGPL theme",
+		"theme-base" => "Base theme",
+	);
+
+	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content";
+	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu";
+	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information";
+
+	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant";
+	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php";
 
 	$_SITE['wb_lang_header_'.$_LANG_] = "Language selection";
 
 	$_SITE['wb_terms_'.$_LANG_] = "Terms and conditions of use";
-	$_SITE['wb_terms_href_'.$_LANG_] = "../../License-en.html";
+	$_SITE['wb_terms_href_'.$_LANG_] = "../../license-en.php";
 
-	$_SITE['wb_mb_menu_'.$_LANG_] = "Menu";
+	$_SITE['wb_mb_menu_'.$_LANG_] = "Search and menus";
 
-	//used in foot-nav.php
-	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu"; 
+	// Used in foot-nav.php.
+	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu";
 
-	//used in cont/foot.php
-	$_SITE['wb_foot_'.$_LANG_] = "Site Information"; 
+	// Used in cont/foot.php.
+	$_SITE['wb_foot_'.$_LANG_] = "About this site";
 
-	//$_MENU_LOCATION__ is set in the parent config.php file
+	// $_MENU_LOCATION__ is set in the parent config.php file.
 	$_SITE['wb_sitenav_file_'.$_LANG_] = $_MENU_LOCATION_ ."/prim-megamenu-en.php";
-	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu"; 
+	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu";
 
 	$_SITE['wb_ft1_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-1-en.php";
 	$_SITE['wb_ft1_href_'.$_LANG_] = "#";
-	$_SITE['wb_ft1_text_'.$_LANG_] = "About";
+	$_SITE['wb_ft1_text_'.$_LANG_] = "Contact us";
 
 	$_SITE['wb_ft2_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-2-en.php";
 	$_SITE['wb_ft2_href_'.$_LANG_] = "#";
-	$_SITE['wb_ft2_text_'.$_LANG_] = "Contact us";
+	$_SITE['wb_ft2_text_'.$_LANG_] = "About";
 
 	$_SITE['wb_ft3_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-3-en.php";
 	$_SITE['wb_ft3_href_'.$_LANG_] = "#";
@@ -44,48 +53,51 @@
 	$_SITE['wb_ft4_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-4-en.php";
 	$_SITE['wb_ft4_href_'.$_LANG_] = "#";
 	$_SITE['wb_ft4_text_'.$_LANG_] = "Stay connected";
-	
-	$_SITE['wb_search_'.$_LANG_] = "Search"; 
-	$_SITE['wb_search_label_'.$_LANG_] = "Search Website"; 
 
-	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail"; 
-	
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:";
+	$_SITE['wb_search_'.$_LANG_] = "Search";
+	$_SITE['wb_search_label_'.$_LANG_] = "Search Website";
 
-	$_STIE['wb_err_return_text_'.$_LANG_] = 'Return to the ';
-	$_STIE['wb_err_return_link_'.$_LANG_] = 'home page';
+	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail";
 
+	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; // Visible if $_SITE['isapp'] == 0.
+	$_SITE['wb_doc_version_'.$_LANG_] = "Version:";     // Visible if $_SITE['isapp'] == 1.
+
+	// Visible if $_PAGE['isarchived'] == 1.
 	$_SITE['wb_archive_title_'.$_LANG_] = "ARCHIVED - ";
 	$_SITE['wb_archive_panel_title_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "warrning";
+	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "Warning";
 	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	
-	//The following variables were used in version 3.1, but not in version 4.0
-	/*	
-	//Modify to point to a custom signin/signout application
-	//Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos
-	$_SITE['wb_signin_file_'.$_LANG_] = "application-signout-en.php";
+
+	$_STIE['wb_err_return_text_'.$_LANG_] = "Return to the ";
+	$_STIE['wb_err_return_link_'.$_LANG_] = "home page";
+
+	// Modify to point to a custom button bar.
+	$_SITE['wb_buttonbar_file_'.$_LANG_] = "../inc/button-bar.php";
+
+	// Modify to point to a custom signin application.
+	// Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signin'] == 1.
+	$_SITE['wb_signin_href_'.$_LANG_] = "#";
+	$_SITE['wb_signininfo_text_'.$_LANG_] = "Sign-on information";
 	$_SITE['wb_signin_text_'.$_LANG_] = "Sign in";
-	
-	//Modify to point to a custom signin/signout application
-	//Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos
-	$_SITE['wb_signout_file_'.$_LANG_] = "application-signin-en.php";
+
+	// Modify to point to a custom registration application.
+	// Override the 'wb_register_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['register'] == 1 and $_PAGE['signin'] == 1.
+	$_SITE['wb_register_href_'.$_LANG_] = "#";
+	$_SITE['wb_register_text_'.$_LANG_] = "Register";
+
+	// Modify to point to a custom signout application.
+	// Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signout'] == 1.
+	$_SITE['wb_signout_href_'.$_LANG_] = "#";
 	$_SITE['wb_signout_text_'.$_LANG_] = "Sign out";
+	$_SITE['wb_signedinas_text_'.$_LANG_] = "Signed in as";
+	$_SITE['wb_username_text'] = "";
 
-	//Modify to point to a custom account settings application when using sign in/sign out button
-	$_SITE['wb_sio_file_'.$_LANG_] = "#";
-	$_SITE['wb_sio_text_'.$_LANG_] = "Account settings";
-	$_SITE['wb_sio_heading_'.$_LANG_] = "My account";
-
-	$_SITE['wb_sup_'.$_LANG_] = "Supplemental content"; 
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; 
-	$_SITE['wb_doc_version_'.$_LANG_] = "Version:"; 
-	$_SITE['wb_sitefooter_'.$_LANG_] = "Site footer"; 
-
-	$_SITE['wb_archive_warn_alt_'.$_LANG_] = "Warning";
-	$_SITE['wb_archive_warn_title_'.$_LANG_] = $_SITE['wb_archive_warn_alt'.$_LANG_];
-	$_SITE['wb_archive_warn_webuse_'.$_LANG_] = "The <a href='http://www.tbs-sct.gc.ca/pol/doc-en.aspx?id=24227'>Standard on Web Usability</a> replaces this content. This content is archived because Common Look and Feel 2.0 Standards have been rescinded.";
-	$_SITE['wb_archive_warn_head_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	*/
-?>
+	// Modify to point to a custom account settings application.
+	// Override the 'wb_settings_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['settings'] == 1 and $_PAGE['signout'] == 1.
+	$_SITE['wb_settings_href_'.$_LANG_] = "#";
+	$_SITE['wb_settings_text_'.$_LANG_] = "Account settings";
+	$_SITE['wb_settings_heading_'.$_LANG_] = "My account";

--- a/dist-php/config/config-ru.php
+++ b/dist-php/config/config-ru.php
@@ -1,41 +1,50 @@
 <?php
-	/*	THIS FILE REQUIRES TRANSLATION */
+	/* THIS FILE REQUIRES TRANSLATION */
 	$_LANG_ = "ru";
-	$_SITE['wb_meta_'.$_LANG_] = "ru"; 
-	$_SITE['wb_lang_text_'.$_LANG_] = "&#1056;&#1091;&#1089;&#1089;&#1082;&#1080;&#1081;"; 
+	$_SITE['wb_meta_'.$_LANG_] = "ru";
+	$_SITE['wb_lang_text_'.$_LANG_] = "&#1056;&#1091;&#1089;&#1089;&#1082;&#1080;&#1081;";
 	$_SITE['wb_lang_cur_'.$_LANG_] = "(current)";
 
-	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content"; 
-	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu"; 
-	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information"; 
-	
-	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant"; 
-	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php"; 
+	$_SITE['theme_list_'.$_LANG_] = array(
+		"theme-gcwu-fegc" => "Government of Canada Web Usability theme",
+		"theme-gcweb" => "Canada.ca theme",
+		"theme-wet-boew" => "WET theme",
+		"theme-gc-intranet" => "Government of Canada Web Usability Intranet theme",
+		"theme-ogpl" => "OGPL theme",
+		"theme-base" => "Base theme",
+	);
+
+	$_SITE['wb_sh_link_1_'.$_LANG_] = "Skip to main content";
+	$_SITE['wb_sh_link_2_'.$_LANG_] = "Skip to secondary menu";
+	$_SITE['wb_sh_link_3_'.$_LANG_] = "Skip to site information";
+
+	$_SITE['wb_site_title_'.$_LANG_] = "PHP Variant";
+	$_SITE['wb_site_href_'.$_LANG_] = "home-accueil-en.php";
 
 	$_SITE['wb_lang_header_'.$_LANG_] = "Language selection";
 
 	$_SITE['wb_terms_'.$_LANG_] = "Terms and conditions of use";
-	$_SITE['wb_terms_href_'.$_LANG_] = "../../License-en.html";
+	$_SITE['wb_terms_href_'.$_LANG_] = "../../license-en.php";
 
-	$_SITE['wb_mb_menu_'.$_LANG_] = "Menu";
+	$_SITE['wb_mb_menu_'.$_LANG_] = "Search and menus";
 
-	//used in foot-nav.php
-	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu"; 
+	// Used in foot-nav.php.
+	$_SITE['wb_sec_'.$_LANG_] = "Secondary menu";
 
-	//used in cont/foot.php
-	$_SITE['wb_foot_'.$_LANG_] = "Site Information"; 
+	// Used in cont/foot.php.
+	$_SITE['wb_foot_'.$_LANG_] = "About this site";
 
-	//$_MENU_LOCATION__ is set in the parent config.php file
+	// $_MENU_LOCATION__ is set in the parent config.php file.
 	$_SITE['wb_sitenav_file_'.$_LANG_] = $_MENU_LOCATION_ ."/prim-megamenu-en.php";
-	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu"; 
+	$_SITE['wb_sitenav_'.$_LANG_] = "Site menu";
 
 	$_SITE['wb_ft1_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-1-en.php";
 	$_SITE['wb_ft1_href_'.$_LANG_] = "#";
-	$_SITE['wb_ft1_text_'.$_LANG_] = "About";
+	$_SITE['wb_ft1_text_'.$_LANG_] = "Contact us";
 
 	$_SITE['wb_ft2_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-2-en.php";
 	$_SITE['wb_ft2_href_'.$_LANG_] = "#";
-	$_SITE['wb_ft2_text_'.$_LANG_] = "Contact us";
+	$_SITE['wb_ft2_text_'.$_LANG_] = "About";
 
 	$_SITE['wb_ft3_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-3-en.php";
 	$_SITE['wb_ft3_href_'.$_LANG_] = "#";
@@ -44,48 +53,51 @@
 	$_SITE['wb_ft4_menu_file_'.$_LANG_] = $_MENU_LOCATION_ ."/trail-4-en.php";
 	$_SITE['wb_ft4_href_'.$_LANG_] = "#";
 	$_SITE['wb_ft4_text_'.$_LANG_] = "Stay connected";
-	
-	$_SITE['wb_search_'.$_LANG_] = "Search"; 
-	$_SITE['wb_search_label_'.$_LANG_] = "Search Website"; 
 
-	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail"; 
-	
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:";
+	$_SITE['wb_search_'.$_LANG_] = "Search";
+	$_SITE['wb_search_label_'.$_LANG_] = "Search Website";
 
-	$_STIE['wb_err_return_text_'.$_LANG_] = 'Return to the ';
-	$_STIE['wb_err_return_link_'.$_LANG_] = 'home page';
-	
+	$_SITE['wb_bcrumb_'.$_LANG_] = "Breadcrumb trail";
+
+	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; // Visible if $_SITE['isapp'] == 0.
+	$_SITE['wb_doc_version_'.$_LANG_] = "Version:";     // Visible if $_SITE['isapp'] == 1.
+
+	// Visible if $_PAGE['isarchived'] == 1.
 	$_SITE['wb_archive_title_'.$_LANG_] = "ARCHIVED - ";
 	$_SITE['wb_archive_panel_title_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "warrning";
+	$_SITE['wb_archive_panel_glyph_'.$_LANG_] = "Warning";
 	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	
-	//The following variables were used in version 3.1, but not in version 4.0
-	/*	
-	//Modify to point to a custom signin/signout application
-	//Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos
-	$_SITE['wb_signin_file_'.$_LANG_] = "application-signout-en.php";
+
+	$_STIE['wb_err_return_text_'.$_LANG_] = "Return to the ";
+	$_STIE['wb_err_return_link_'.$_LANG_] = "home page";
+
+	// Modify to point to a custom button bar.
+	$_SITE['wb_buttonbar_file_'.$_LANG_] = "../inc/button-bar.php";
+
+	// Modify to point to a custom signin application.
+	// Override the 'wb_signin_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signin'] == 1.
+	$_SITE['wb_signin_href_'.$_LANG_] = "#";
+	$_SITE['wb_signininfo_text_'.$_LANG_] = "Sign-on information";
 	$_SITE['wb_signin_text_'.$_LANG_] = "Sign in";
-	
-	//Modify to point to a custom signin/signout application
-	//Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos
-	$_SITE['wb_signout_file_'.$_LANG_] = "application-signin-en.php";
+
+	// Modify to point to a custom registration application.
+	// Override the 'wb_register_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['register'] == 1 and $_PAGE['signin'] == 1.
+	$_SITE['wb_register_href_'.$_LANG_] = "#";
+	$_SITE['wb_register_text_'.$_LANG_] = "Register";
+
+	// Modify to point to a custom signout application.
+	// Override the 'wb_signout_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['signout'] == 1.
+	$_SITE['wb_signout_href_'.$_LANG_] = "#";
 	$_SITE['wb_signout_text_'.$_LANG_] = "Sign out";
+	$_SITE['wb_signedinas_text_'.$_LANG_] = "Signed in as";
+	$_SITE['wb_username_text'] = "";
 
-	//Modify to point to a custom account settings application when using sign in/sign out button
-	$_SITE['wb_sio_file_'.$_LANG_] = "#";
-	$_SITE['wb_sio_text_'.$_LANG_] = "Account settings";
-	$_SITE['wb_sio_heading_'.$_LANG_] = "My account";
-
-	$_SITE['wb_sup_'.$_LANG_] = "Supplemental content"; 
-	$_SITE['wb_doc_dates_'.$_LANG_] = "Date modified:"; 
-	$_SITE['wb_doc_version_'.$_LANG_] = "Version:"; 
-	$_SITE['wb_sitefooter_'.$_LANG_] = "Site footer"; 
-
-	$_SITE['wb_archive_warn_alt_'.$_LANG_] = "Warning";
-	$_SITE['wb_archive_warn_title_'.$_LANG_] = $_SITE['wb_archive_warn_alt'.$_LANG_];
-	$_SITE['wb_archive_warn_webuse_'.$_LANG_] = "The <a href='http://www.tbs-sct.gc.ca/pol/doc-en.aspx?id=24227'>Standard on Web Usability</a> replaces this content. This content is archived because Common Look and Feel 2.0 Standards have been rescinded.";
-	$_SITE['wb_archive_warn_head_'.$_LANG_] = "Archived Content";
-	$_SITE['wb_archive_warn_msg_'.$_LANG_] = "Information identified as archived is provided for reference, research or recordkeeping purposes. It is not subject to the Government of Canada Web Standards and has not been altered or updated since it was archived. Please contact us to request a format other than those available.";
-	*/
-?>
+	// Modify to point to a custom account settings application.
+	// Override the 'wb_settings_file_'.$_LANG_ variable in the file calling it, the default is for demos.
+	// Visible if $_PAGE['settings'] == 1 and $_PAGE['signout'] == 1.
+	$_SITE['wb_settings_href_'.$_LANG_] = "#";
+	$_SITE['wb_settings_text_'.$_LANG_] = "Account settings";
+	$_SITE['wb_settings_heading_'.$_LANG_] = "My account";

--- a/dist-php/inc/button-bar.php
+++ b/dist-php/inc/button-bar.php
@@ -1,0 +1,22 @@
+<?php
+if (!empty($_PAGE['signin']) || !empty($_PAGE['signout'])) {
+	echo '<section id="wb-so">';
+	echo '<h2 class="wb-inv">'.$_SITE['wb_signininfo_text_'.$_LANG_].'</h2>';
+	echo '<div class="container"><div class="row"><div class="col-md-12">';
+	if (!empty($_PAGE['signin'])) {
+		if (!empty($_PAGE['register'])) {
+			echo '<a href="' . $_SITE['wb_register_href_'.$_LANG_] . '" class="btn btn-default wb-register">' . $_SITE['wb_register_text_'.$_LANG_] . '</a> ';
+		}
+		echo '<a href="' . $_SITE['wb_signin_href_'.$_LANG_] . '" class="btn btn-primary wb-signin">' . $_SITE['wb_signin_text_'.$_LANG_] . '</a>';
+	} elseif (!empty($_PAGE['signout'])) {
+		if (!empty($_SITE['wb_username_text'])) {
+			echo '<p style="display:inline-block;margin-right:10px;">' . $_SITE['wb_signedinas_text_'.$_LANG_] . ' ' . $_SITE['wb_username_text'] . '</span></p>';
+		}
+		if (!empty($_PAGE['settings'])) {
+			echo '<a href="' . $_SITE['wb_settings_href_'.$_LANG_] . '" class="btn btn-default wb-settings">' . $_SITE['wb_settings_text_'.$_LANG_] . '</a> ';
+		}
+		echo '<a href="' . $_SITE['wb_signout_href_'.$_LANG_] . '" class="btn btn-primary wb-signout">' . $_SITE['wb_signout_text_'.$_LANG_] . '</a>';
+	}
+	echo '</div></div></div>';
+	echo '</section>';
+}

--- a/dist-php/inc/head-nav.php
+++ b/dist-php/inc/head-nav.php
@@ -70,6 +70,8 @@ if (($_PAGE['iserror'] != '1') && isset($_PAGE['left_menu_gauche']) && $_PAGE['l
 }
 
 if ($_PAGE['issplash'] != '1' && $_PAGE['iserror'] != '1') {
+    include $_SITE['wb_buttonbar_file_' . $_PAGE['lang1']];
+
     echo '<h1 id="wb-cont" property="name">';
     if ($_PAGE['isarchived'] == "1") {
         $_TITLE_ = $_SITE['wb_archive_title_' . $_PAGE['lang1']] . $_PAGE['short_title_' . $_PAGE['lang1']];


### PR DESCRIPTION
**DETAILS**
- Added support for Sign in/out, Register, Account Settings button bar and Version (for applications) in footer.
- All config language files now include the same list of variables. Non-English/French versions still need translations.

**DOCUMENTATION**

The access control button bar will only appear if all of the following conditions are met:
- $_PAGE['issplash'] != '1' and $_PAGE['iserror'] != '1'; and
- $_PAGE['signin'] == '1'  or $_PAGE['signout'] == '1'

**Register / Sign in**
![image](https://cloud.githubusercontent.com/assets/3808579/19670587/7c4516f6-9a36-11e6-8fa2-57cbe01ce3d0.png)

The **Sign in** and **Register** buttons are controlled by the following variables:

```
 // Control the display of the Sign In button.
 $_PAGE['signin'] = '1'; // 0 = not displayed, 1 = displayed.

 // The rest will only be displayed if $_PAGE['signin'] == '1' :

 // URL of button linking to application's Sign in process.
 $_SITE['wb_signin_href_' . $_LANG_] = "http://example.com/login/login.php";

 // Control the display of the Register button.
 $_PAGE['register'] = '1'; // 0 = not displayed, 1 = displayed.

 // URL of button linking to application's Register process.
 $_SITE['wb_register_href_' . $_LANG_] = "http://example.com/login/register.php";
```

Examples:
- English: https://wet-boew.github.io/v4.0-ci/theme/content-signedoff-en.html
- French: https://wet-boew.github.io/v4.0-ci/theme/content-signedoff-fr.html

**Signed in as / Account settings / Sign out**
![image](https://cloud.githubusercontent.com/assets/3808579/19670568/463da76c-9a36-11e6-9b88-8cd6168b26fa.png)

The "Signed in as <username>" string as well as the links for the **Register** and **Sign Out** buttons are determined by setting the following variables:

```
 // Control the display of the Sign Out button.
 $_PAGE['signout'] = '1'; // 0 = not displayed, 1 = displayed.

 // The rest will only be displayed if $_PAGE['signout'] == '1' and $_PAGE['signin'] == '0'.

 // URL of button linking to application's Sign out process.
 $_SITE['wb_signout_href_' . $_LANG_] = "http://example.com/login/logout.php";

 // Control the display of the Account Settings button.
 $_PAGE['settings'] = '1'; // 0 = not displayed, 1 = displayed.
 // URL of button linking to application's user Account Settings process.
 $_SITE['wb_settings_href_' . $_LANG_] = "http://example.com/user/settings.php";

 // The "Signed in as <username>" string will not be displayed if the username is blank.
 $_SITE['wb_username_text'] = "John Doe";
```

Examples:
- English: https://wet-boew.github.io/v4.0-ci/theme/content-signedon-en.html
- French: https://wet-boew.github.io/v4.0-ci/theme/content-signedon-fr.html

Developers can optionally override the path to the access control button bar. This will allowing them to create their own custom button bar by setting the $_SITE['wb_buttonbar_file_'.$_LANG_] variable. Example:

```
 $_SITE['wb_buttonbar_file_'.$_LANG_] = "/var/www/yoursite/custom/button-bar.php";
```

Let me know if you have any questions or concerns.

Michael Milette
